### PR TITLE
Fixes kubectl cli reference

### DIFF
--- a/scripts/create-secret.sh
+++ b/scripts/create-secret.sh
@@ -4,6 +4,10 @@ NAMESPACE="$1"
 NAME="$2"
 OUTPUT_DIR="$3"
 
+if [[ -n "${BIN_DIR}" ]]; then
+  export PATH="${BIN_DIR}:${PATH}"
+fi
+
 mkdir -p "${OUTPUT_DIR}"
 
 kubectl create secret generic "${NAME}" \


### PR DESCRIPTION
- Adds bin_dir from clis submodule to path for create_secret

closes #6

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>